### PR TITLE
Refactor startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,8 @@ tags
 # Persistent undo
 [._]*.un~
 
+# Logs
+*.log
+
+# Don't want to commit the PSES build
 PowerShellEditorServices

--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ Plug 'autozimu/LanguageClient-neovim', {
     \ 'branch': 'next',
     \ 'do': 'bash install.sh',
     \ }
+
 " Required for intellisense style completions.
-Plug 'roxma/nvim-completion-manager'
+Plug 'ncm2/ncm2'
+Plug 'roxma/nvim-yarp'
+
+" enable ncm2 for all buffers
+autocmd BufEnter * call ncm2#enable_for_buffer()
+
+" IMPORTANT: :help Ncm2PopupOpen for more information
+set completeopt=noinsert,menuone,noselect
 
 " Required to switch to PowerShell???
 Plug 'sheerun/vim-polyglot'

--- a/plugin/vim-powershell.vim
+++ b/plugin/vim-powershell.vim
@@ -2,19 +2,30 @@
 "required for operations modifying multiple buffers like rename.
 set hidden
 
-let s:path = expand('<sfile>:p:h') . '/PowerShellEditorServices/'
+" Build startup command.
+let s:bundledModulesPath = expand('<sfile>:p:h') . '/PowerShellEditorServices/'
+let startup = ['pwsh', s:bundledModulesPath . 'PowerShellEditorServices/Start-EditorServices.ps1',
+        \ '-HostName', 'nvim',
+        \ '-HostProfileId', '0',
+        \ '-HostVersion', '1.0.0',
+        \ '-LogPath', s:bundledModulesPath . 'pses.log',
+        \ '-LogLevel', 'Diagnostic',
+        \ '-BundledModulesPath', s:bundledModulesPath,
+        \ '-Stdio',
+        \ '-SessionDetailsPath', s:bundledModulesPath . '.pses_session']
 
-let startEditorServicesPath = s:path . 'PowerShellEditorServices/Start-EditorServices.ps1'
+" Set the language client to start when using ps1, psd1, psm1
+if !exists("g:LanguageClient_serverCommands")
+    g:LanguageClient_serverCommands = {}
+endif
 
-" a hash of file types to language server launch command
-let g:LanguageClient_serverCommands = {
-    \ 'ps1': ['pwsh', startEditorServicesPath, '-HostName', 'nvim', '-HostProfileId', '0', '-HostVersion', '1.0.0', '-LogPath', s:path . 'pses.log', '-LogLevel', 'Diagnostic', '-BundledModulesPath', s:path, '-Stdio', '-SessionDetailsPath', s:path . '.pses_session']
-    \ }
+let g:LanguageClient_serverCommands['ps1'] = startup
+let g:LanguageClient_serverCommands['psd1'] = startup
+let g:LanguageClient_serverCommands['psm1'] = startup
 
 " for debugging LanguageClient-neovim
 let g:LanguageClient_loggingLevel = 'DEBUG'
 let g:LanguageClient_loggingFile =  expand('<sfile>:p:h') . 'LanguageClient.log'
-
 let g:LanguageClient_serverStderr = expand('<sfile>:p:h') . 'LanguageServer.log'
 
 " fun with F8
@@ -30,7 +41,8 @@ endfunction
 
 " If the filetype is powershell set up our keybindings
 autocmd FileType ps1 call VsimEnableLanguageServerKeys()
-
+autocmd FileType psm1 call VsimEnableLanguageServerKeys()
+autocmd FileType psd1 call VsimEnableLanguageServerKeys()
 function! VsimEnableLanguageServerKeys()
         " TODO hover with timer
         nnoremap <silent> <S-K> :call PS1Hover()<CR>


### PR DESCRIPTION
This does a few things:

* makes the startup line easier to read
* supports `psd1` and `psm1`
* updates README to use `ncm2`
* don't override `g:LanguageClient_serverCommands` if it already exists